### PR TITLE
Refactor Ruby Gem Formulas to use gem fetch instead of hard coded rubygems.org url

### DIFF
--- a/bin/brew-gem
+++ b/bin/brew-gem
@@ -19,8 +19,7 @@ klass = name.capitalize.gsub(/[-_.\s]([a-zA-Z0-9])/) { $1.upcase }.gsub('+', 'x'
 require 'erb'
 template = ERB.new(File.read(__FILE__).split(/^__END__$/, 2)[1].strip)
 
-require 'tempfile'
-filename = File.join Dir.tmpdir, "#{name}.rb"
+filename = File.join "/usr/local/Cellar/", "#{name}.rb"
 
 begin
   open(filename, 'w') do |f|
@@ -28,22 +27,38 @@ begin
   end
 
   system "brew #{command} #{filename}"
-ensure
-  File.unlink filename
 end
 
 __END__
 require 'formula'
 
-class RubyGemFormula < Formula
-  class NoopDownloadStrategy < AbstractDownloadStrategy
-    def fetch; end
-    def stage; end
+class RubyGemsDownloadStrategy < AbstractDownloadStrategy
+  def fetch
+    ohai "Fetching RubyGem automation"
+    `cd #{HOMEBREW_CACHE} && gem fetch #{name} --version #{resource.version}`
   end
 
-  def download_strategy
-    NoopDownloadStrategy
+  def cached_location
+    Pathname.new("#{HOMEBREW_CACHE}/#{name}-#{resource.version}")
   end
+
+  def clear_cache
+   cached_location.unlink if cached_location.exists?
+  end
+
+  def stage; end
+end
+
+class Resource
+  def download_strategy
+    RubyGemsDownloadStrategy
+  end
+end
+
+
+class <%= klass %> < Formula
+  url "<%= name %>"
+  version "<%= version %>"
 
   def install
     # set GEM_HOME and GEM_PATH to make sure we package all the dependent gems
@@ -51,8 +66,7 @@ class RubyGemFormula < Formula
     # they might not be there if, say, we change to a different rvm gemset
     ENV['GEM_HOME']="#{prefix}"
     ENV['GEM_PATH']="#{prefix}"
-    system "gem", "install", "<%= name %>",
-             "--version", "<%= version %>",
+    system "gem", "install", "#{HOMEBREW_CACHE}/#{name}-#{version}.gem",
              "--no-rdoc", "--no-ri",
              "--no-user-install",
              "--install-dir", prefix,
@@ -73,10 +87,5 @@ load "#{file}"
       end
     end
   end
-end
-
-class <%= klass %> < RubyGemFormula
-  url "http://rubygems.org/downloads/<%= name %>-<%= version %>.gem"
-  homepage "http://rubygems.org/gems/<%= name %>"
 end
 


### PR DESCRIPTION
QA steps:
`brew tap sportngin/hombrew`
`brew edit sportngin-brew-gem`

``` ruby
require 'formula'
class SportnginBrewGem < Formula
  homepage 'https://github.com/sportngin/brew-gem'
  head 'https://github.com/sportngin/brew-gem/archive/use-gem-fetch.tar.gz'

   def install
     bin.install 'bin/brew-gem'
   end
end
```

`brew install --HEAD sportngin-brew-gem`
