### PR TITLE
Fix for dashed gem names

### DIFF
--- a/bin/brew-gem
+++ b/bin/brew-gem
@@ -15,7 +15,7 @@ unless gems.detect { |f| f =~ /^#{name} \(([^\s,]+).*\)/ }
 end
 version = ARGV[2] || $1
 
-klass = name.capitalize.gsub(/[-_.\s]([a-zA-Z0-9])/) { version.upcase }.gsub('+', 'x')
+klass = name.capitalize.gsub(/[-_.\s]([a-zA-Z0-9])/) { $1.upcase }.gsub('+', 'x')
 
 require 'erb'
 template = ERB.new(File.read(__FILE__).split(/^__END__$/, 2)[1].strip)


### PR DESCRIPTION
This essentially reverts one of the changes made in PR #8.

The `$1` global variable has different values at line 16 and line 18.  In line 16,  the `$1` represents the parsed gem version number found in the `gem list --remote "^#{name}$"` command that was run on line 13 and parsed on 14.  The raw output from the command would look something like this:

```

*** REMOTE GEMS ***

rails (4.1.4)
```

And would parse `4.1.4` and set it to `$1`.

The second usage of `$1` (which was mistakenly changed to version in the aforementioned PR) is the value of the match in the regex of the gsub command.  This was the original value, and should remain that since we don't want to replace the portions of the gem name with the version, but to upcase the character following any dash and removing any existing dashes.
