### PR TITLE
Adds --no-wrapper flag for gem installs

### DIFF
--- a/bin/brew-gem
+++ b/bin/brew-gem
@@ -71,7 +71,9 @@ class <%= klass %> < Formula
     ENV['GEM_HOME']="#{prefix}"
     ENV['GEM_PATH']="#{prefix}"
     system "gem", "install", "#{HOMEBREW_CACHE}/#{name}-#{version}.gem",
-             "--no-rdoc", "--no-ri",
+             "--no-ri",
+             "--no-rdoc",
+             "--no-wrapper",
              "--no-user-install",
              "--install-dir", prefix,
              "--bindir", bin


### PR DESCRIPTION
We are adding wrapper bin files to the path ourselves, so it doesn't make sense to have rubygems do it as well.  Also, this avoids conflicts from happening with duplicate bin file names on install, which requires user input and keeps homebrew from finishing the install.
