### PR TITLE
Add basic support for --pre

### DIFF
--- a/bin/brew-gem
+++ b/bin/brew-gem
@@ -9,7 +9,8 @@ end
 
 command = ARGV[0]
 name = ARGV[1]
-gems = `gem list --remote "^#{name}$"`.lines
+pre = ENV['ALLOW_PRE_RELEASE_GEMS'] ? 'pre' : nil
+gems = `gem list --remote #{pre} "^#{name}$"`.lines
 unless gems.detect { |f| f =~ /^#{name} \(([^\s,]+).*\)/ }
   abort "Could not find a valid gem '#{name}'"
 end

--- a/bin/brew-gem
+++ b/bin/brew-gem
@@ -9,7 +9,7 @@ end
 
 command = ARGV[0]
 name = ARGV[1]
-pre = ENV['ALLOW_PRE_RELEASE_GEMS'] ? 'pre' : nil
+pre = ENV['ALLOW_PRE_RELEASE_GEMS'] ? '--pre' : nil
 gems = `gem list --remote #{pre} "^#{name}$"`.lines
 unless gems.detect { |f| f =~ /^#{name} \(([^\s,]+).*\)/ }
   abort "Could not find a valid gem '#{name}'"


### PR DESCRIPTION
Description
----------------
This is a temporary solution for adding support for pre release based gems.  An example for this is the octopress gem:

![screen shot 2015-03-18 at 10 46 17 am](https://cloud.githubusercontent.com/assets/314014/6712718/110a161e-cd5c-11e4-86f8-625a6ef3672f.png)

Which currently only has pre-release gems, and can not be installed in any for currently.


### Notes for the future

This is a hack, and I don't really like solving the problem in this way, but it is the simplest for the time being.  In reality, we really should move away from a single file installation and move towards a more structured library.  I have outlined what I think is required to accomplish this here:  https://github.com/sportngin/brew-gem/issues/16


QA
----
Not the easiest to QA, but here are two possible ways to get this code in place:

1. Modify your `brew-gem` bin file locally with the changes from this PR.  Should be located here:  `/usr/local/Cellar/brew-gem/CURRENT_VERSION_NUMBER/bin/brew-gem`.
  
2. Check out this branch, make a tar of the bin directory, and install the formula using the following (requires that brew-gem is not installed currently):
  
  ```
  $ git checkout add_basic_support_for_--pre
  $ cd ..
  $ tar --exclude .git -cvf ~/brew-gem-test-for-pr-17.tar.gz brew-gem
  $ shasum ~/brew-gem-test-for-pr-17.tar.gz
  $ curl https://raw.githubusercontent.com/Homebrew/homebrew/master/Library/Formula/brew-gem.rb > brew-gem.rb
  $ sed -i '' "s/url \".*\"/url \"file:\/\/$(ls ~/brew-gem-test-for-pr-17.tar.gz | sed 's/\//\\\//g')\"/" brew-gem.rb
  $ sed -i '' "s/sha1 \".*\"/sha1 \"$(shasum ~/brew-gem-test-for-pr-17.tar.gz | cut -d ' ' -f 1)\"/" brew-gem.rb
  $ brew install brew-gem.rb
  ```

Once you have done one of the above, try installing `octopress` by doing the following:

```
$ ALLOW_PRE_RELEASE_GEMS=1 brew gem install octopress
```