### PR TITLE
add prefix of 'gem-' to the formula file name, added 'Gem' prefix to klass name in Formula

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,14 @@ To uninstall:
 
     brew gem uninstall heroku
 
+To check information:
+
+    brew gem info heroku
+
+Note:
+
+Installed gems are listed in `brew list` with prefix of `gem-`,
+like `gem-heroku`.
 
 ### BASH/ZSH Completions
 

--- a/bin/brew-gem
+++ b/bin/brew-gem
@@ -15,14 +15,14 @@ unless gems.detect { |f| f =~ /^#{name} \(([^\s,]+).*\)/ }
 end
 version = ARGV[2] || $1
 
-klass = name.capitalize.gsub(/[-_.\s]([a-zA-Z0-9])/) { $1.upcase }.gsub('+', 'x')
+klass = 'Gem' + name.capitalize.gsub(/[-_.\s]([a-zA-Z0-9])/) { $1.upcase }.gsub('+', 'x')
 user_gemrc = "#{ENV['HOME']}/.gemrc"
 
 require 'erb'
 template = ERB.new(File.read(__FILE__).split(/^__END__$/, 2)[1].strip)
 
 require 'tempfile'
-filename = File.join Dir.tmpdir, "#{name}.rb"
+filename = File.join Dir.tmpdir, "gem-#{name}.rb"
 
 begin
   open(filename, 'w') do |f|


### PR DESCRIPTION
Some gems have names which conflict to Homebrew's formulae, such `git`.

To avoid a conflict, I think it is good to add `gem-` prefix to the formula name,
like [brew-pip](https://github.com/hanxue/brew-pip).

This also makes obvious which one was installed by `brew gem` in `brew list`
and then easier to management.