### PR TITLE
Read executables from gemspec

### DIFF
--- a/lib/brew/gem/formula.rb.erb
+++ b/lib/brew/gem/formula.rb.erb
@@ -61,8 +61,9 @@ class <%= klass %> < Formula
                          ].first
     zsh_completion.install completion_for_zsh if completion_for_zsh
 
+    bindir = Gem::Specification::load("#{prefix}/specifications/<%= name %>-#{version}.gemspec").bindir
     ruby_libs = Dir.glob("#{prefix}/gems/*/lib")
-    Pathname.glob("#{brew_gem_prefix}/bin/*").each do |file|
+    Pathname.glob("#{brew_gem_prefix}/#{bindir}/*").each do |file|
       (bin+file.basename).open('w') do |f|
         f << <<-RUBY
 #!/usr/bin/ruby

--- a/lib/brew/gem/formula.rb.erb
+++ b/lib/brew/gem/formula.rb.erb
@@ -61,9 +61,10 @@ class <%= klass %> < Formula
                          ].first
     zsh_completion.install completion_for_zsh if completion_for_zsh
 
-    bindir = Gem::Specification::load("#{prefix}/specifications/<%= name %>-#{version}.gemspec").bindir
+    gemspec = Gem::Specification::load("#{prefix}/specifications/<%= name %>-#{version}.gemspec")
     ruby_libs = Dir.glob("#{prefix}/gems/*/lib")
-    Pathname.glob("#{brew_gem_prefix}/#{bindir}/*").each do |file|
+    gemspec.executables.each do |exe|
+      file = Pathname.new("#{brew_gem_prefix}/#{gemspec.bindir}/#{exe}")
       (bin+file.basename).open('w') do |f|
         f << <<-RUBY
 #!/usr/bin/ruby

--- a/lib/brew/gem/version.rb
+++ b/lib/brew/gem/version.rb
@@ -1,5 +1,5 @@
 module Brew
   module Gem
-    VERSION = "0.7.2"
+    VERSION = "0.7.3"
   end
 end


### PR DESCRIPTION
Addresses issue #20.

Read executable directory and filenames from the gemspec when creating links, because some gems may use a directory other than bin (for example, exe).

Some gemspecs may have dependencies (Bundler 1.12's gemspec uses git), so the installed gemspec is used.