### PR TITLE
Allow brew-gem to accept a '--homebrew-ruby' flag that uses /usr/local/bin/ruby instead of /usr/bin/ruby

### DIFF
--- a/.ruby-gemset
+++ b/.ruby-gemset
@@ -1,0 +1,1 @@
+brew-gem

--- a/Gemfile
+++ b/Gemfile
@@ -1,4 +1,5 @@
 source 'https://rubygems.org'
 
 # Specify your gem's dependencies in brew-gem.gemspec
+gem 'rake', '~>11.0'
 gemspec

--- a/README.md
+++ b/README.md
@@ -59,11 +59,19 @@ Usage
 To install a specific version:
 
     brew gem install heroku 3.8.3
-    
+
+To install using a brew installed ruby(/usr/local/bin/ruby):
+
+    brew gem install heroku --homebrew-ruby
+
+And with a specific version:
+
+    brew gem install heroku 3.8.3 --homebrew-ruby
+
 To upgrade:
 
     brew gem upgrade heroku
-    
+
 To uninstall:
 
     brew gem uninstall heroku

--- a/lib/brew/gem/cli.rb
+++ b/lib/brew/gem/cli.rb
@@ -38,10 +38,10 @@ module Brew::Gem::CLI
       exit 0
     end
 
-    args[0..2]
+    args[0..3]
   end
 
-  def expand_formula(name, version)
+  def expand_formula(name, version, use_homebrew_ruby=false)
     klass         = 'Gem' + name.capitalize.gsub(/[-_.\s]([a-zA-Z0-9])/) { $1.upcase }.gsub('+', 'x')
     user_gemrc    = "#{ENV['HOME']}/.gemrc"
     template_file = File.expand_path('../formula.rb.erb', __FILE__)
@@ -49,11 +49,11 @@ module Brew::Gem::CLI
     template.result(binding)
   end
 
-  def with_temp_formula(name, version)
+  def with_temp_formula(name, version, use_homebrew_ruby)
     filename = File.join Dir.tmpdir, "gem-#{name}.rb"
 
     open(filename, 'w') do |f|
-      f.puts expand_formula(name, version)
+      f.puts expand_formula(name, version, use_homebrew_ruby)
     end
 
     yield filename
@@ -62,11 +62,18 @@ module Brew::Gem::CLI
   end
 
   def run(args = ARGV)
-    command, name, supplied_version = process_args(args)
+    command, name, supplied_version, homebrew_ruby = process_args(args)
+    homebrew_ruby_flag = "--homebrew-ruby"
+    if supplied_version == homebrew_ruby_flag
+      supplied_version = nil
+      homebrew_ruby = homebrew_ruby_flag
+    end
+
+    use_homebrew_ruby = homebrew_ruby == homebrew_ruby_flag
 
     version = fetch_version(name, supplied_version)
 
-    with_temp_formula(name, version) do |filename|
+    with_temp_formula(name, version, use_homebrew_ruby) do |filename|
       system "brew #{command} #{filename}"
     end
   end

--- a/lib/brew/gem/formula.rb.erb
+++ b/lib/brew/gem/formula.rb.erb
@@ -36,7 +36,11 @@ class <%= klass %> < Formula
     # they might not be there if, say, we change to a different rvm gemset
     ENV['GEM_HOME']="#{prefix}"
     ENV['GEM_PATH']="#{prefix}"
-    system "gem", "install", cached_download,
+
+    rubybindir = '<%= use_homebrew_ruby ? "/usr/local/bin" : "/usr/bin" %>'
+    gem_path = "#{rubybindir}/gem"
+    ruby_path = "#{rubybindir}/ruby"
+    system gem_path, "install", cached_download,
              "--no-ri",
              "--no-rdoc",
              "--no-wrapper",
@@ -67,7 +71,7 @@ class <%= klass %> < Formula
       file = Pathname.new("#{brew_gem_prefix}/#{gemspec.bindir}/#{exe}")
       (bin+file.basename).open('w') do |f|
         f << <<-RUBY
-#!/usr/bin/ruby
+#!#{ruby_path}
 ENV['GEM_HOME']="#{prefix}"
 ENV['GEM_PATH']="#{prefix}"
 $:.unshift(#{ruby_libs.map(&:inspect).join(",")})

--- a/spec/brew/gem/cli_spec.rb
+++ b/spec/brew/gem/cli_spec.rb
@@ -2,16 +2,23 @@ require 'spec_helper'
 
 RSpec.describe Brew::Gem::CLI do
   context "#expand_formula" do
-    subject(:formula) { described_class.expand_formula("foo-bar", "1.2.3") }
+    subject(:formula) { described_class.expand_formula("foo-bar", "1.2.3", false) }
 
     it "generates valid Ruby" do
       IO.popen("ruby -c -", "r+") { |f| f.puts formula }
+
       expect($?).to be_success
     end
 
     it { is_expected.to match(/class GemFooBar < Formula/) }
 
     it { is_expected.to match(/version "1\.2\.3"/) }
+    it { is_expected.to match("rubybindir = '/usr/bin'") }
+
+    context "homebrew-ruby" do
+      subject(:formula) { described_class.expand_formula("foo-bar", "1.2.3", true) }
+      it { is_expected.to match("rubybindir = '/usr/local/bin'") }
+    end
   end
 
 end


### PR DESCRIPTION
Description and Impact
----------------------
This hopefully address the request from #28

This is sort of a stop gap to allow people to select what version of ruby they want to use. The main caveat being that you can't use an unlinked version of homebrew ruby. Or a ruby installed anywhere besides /usr/local/bin/ruby. I'm sort of ok with that for now. If we want to allow passing a location for ruby in the future we can.