### PR TITLE
brew-gem exits non-zero if gem failed to build/install

### DIFF
--- a/lib/brew/gem/cli.rb
+++ b/lib/brew/gem/cli.rb
@@ -68,6 +68,7 @@ module Brew::Gem::CLI
 
     with_temp_formula(name, version) do |filename|
       system "brew #{command} #{filename}"
+      exit $?.exitstatus unless $?.success?
     end
   end
 end

--- a/lib/brew/gem/formula.rb.erb
+++ b/lib/brew/gem/formula.rb.erb
@@ -44,6 +44,8 @@ class <%= klass %> < Formula
              "--install-dir", prefix,
              "--bindir", bin
 
+    raise "gem install '<%= name %>' failed with status #{$?.exitstatus}" unless $?.success?
+
     bin.rmtree if bin.exist?
     bin.mkpath
 


### PR DESCRIPTION
Previously brew-gem would silently succeed if any gems failed to build or install. This propagates the failure of `system("gem install ...")` up through the formula installation and the brew-gem command.