### PR TITLE
added --ignore-dependencies option to uninstall

### DIFF
--- a/lib/brew/gem/cli.rb
+++ b/lib/brew/gem/cli.rb
@@ -74,6 +74,10 @@ module Brew::Gem::CLI
 
     version = fetch_version(name, supplied_version)
 
+    if command == "uninstall"
+      command = "uninstall --ignore-dependencies"
+    end
+
     with_temp_formula(name, version, use_homebrew_ruby) do |filename|
       system "brew #{command} #{filename}"
       exit $?.exitstatus unless $?.success?


### PR DESCRIPTION
The recent update of Homebrew changes to check package dependencies at `uninstall`.

[Merge pull request #1082 from alyssais/uninstall_dependancy_error ·  Homebrew/brew@2ce17a1](https://github.com/Homebrew/brew/commit/2ce17a11379a45e5de7e09a57681006aca5206bd#diff-e531dd4c9cd52c3f7a3900930f6c42ce)

For brew-gem installed packages, they don't have Formula then it will make an error like:

    $ brew gem uninstall heroku
    Error: No available formula with the name "gem-heroku"

This can be avoided by using `--ignore-dependencies` option.

In the pull request, it adds this option when `uninstall` command is given to `brew-gem`.