### PR TITLE
Use bash shim to set GEM_* envvars

### DIFF
--- a/lib/brew/gem/formula.rb.erb
+++ b/lib/brew/gem/formula.rb.erb
@@ -73,9 +73,12 @@ class <%= klass %> < Formula
       file = Pathname.new("#{brew_gem_prefix}/#{gemspec.bindir}/#{exe}")
       (bin+file.basename).open('w') do |f|
         f << <<-RUBY
+#!/bin/bash
+unset RUBYOPT
+export GEM_HOME="#{prefix}"
+export GEM_PATH="#{prefix}"
+exec #{ruby_path} -x "$0" "$@"
 #!#{ruby_path}
-ENV['GEM_HOME']="#{prefix}"
-ENV['GEM_PATH']="#{prefix}"
 $:.unshift(#{ruby_libs.map(&:inspect).join(",")})
 load "#{file}"
         RUBY


### PR DESCRIPTION
What
----------------------
Changes the launcher scripts installed by brew-gem to use a bash shim to manipulate environment variables before launching Ruby.

Why
----------------------
I've seen some side effects when running a script installed by brew-gem in the context of a project using a different Ruby (e.g., an RVM-installed Ruby). Specifically, Ruby seems to initially scan `$GEM_HOME` (which is set to the RVM gemset) at load time and it emits warnings for gems with native libraries that don't match the Ruby running the brew-gem script. Changing the `GEM_*` environment variables before launching Ruby avoids the warnings.

Before the change:

```
$ opsicle --help
Ignoring bcrypt-3.1.11 because its extensions are not built.  Try: gem pristine bcrypt --version 3.1.11
Ignoring bcrypt-3.1.10 because its extensions are not built.  Try: gem pristine bcrypt --version 3.1.10
Ignoring binding_of_caller-0.7.2 because its extensions are not built.  Try: gem pristine binding_of_caller --version 0.7.2
Ignoring bond-0.4.1 because its extensions are not built.  Try: gem pristine bond --version 0.4.1
Ignoring byebug-8.2.2 because its extensions are not built.  Try: gem pristine byebug --version 8.2.2
Ignoring debug_inspector-0.0.2 because its extensions are not built.  Try: gem pristine debug_inspector --version 0.0.2
Ignoring executable-hooks-1.3.2 because its extensions are not built.  Try: gem pristine executable-hooks --version 1.3.2
Ignoring ffi-1.9.14 because its extensions are not built.  Try: gem pristine ffi --version 1.9.14
Ignoring ffi-1.9.11 because its extensions are not built.  Try: gem pristine ffi --version 1.9.11
Ignoring ffi-1.9.10 because its extensions are not built.  Try: gem pristine ffi --version 1.9.10
Ignoring gem-wrappers-1.2.7 because its extensions are not built.  Try: gem pristine gem-wrappers --version 1.2.7
Ignoring image_science-1.3.2.1.Asynchrony because its extensions are not built.  Try: gem pristine image_science --version 1.3.2.1.Asynchrony
Ignoring json-1.8.6 because its extensions are not built.  Try: gem pristine json --version 1.8.6
Ignoring json-1.8.3 because its extensions are not built.  Try: gem pristine json --version 1.8.3
Ignoring kgio-2.10.0 because its extensions are not built.  Try: gem pristine kgio --version 2.10.0
Ignoring libv8-3.16.14.15 because its extensions are not built.  Try: gem pristine libv8 --version 3.16.14.15
Ignoring mysql2-0.3.20 because its extensions are not built.  Try: gem pristine mysql2 --version 0.3.20
Ignoring nokogiri-1.6.8 because its extensions are not built.  Try: gem pristine nokogiri --version 1.6.8
Ignoring nokogiri-1.6.8.rc3 because its extensions are not built.  Try: gem pristine nokogiri --version 1.6.8.rc3
Ignoring redcarpet-3.3.4 because its extensions are not built.  Try: gem pristine redcarpet --version 3.3.4
Ignoring sqlite3-1.3.11 because its extensions are not built.  Try: gem pristine sqlite3 --version 1.3.11
Ignoring syck-1.0.5 because its extensions are not built.  Try: gem pristine syck --version 1.0.5
Ignoring therubyracer-0.12.2 because its extensions are not built.  Try: gem pristine therubyracer --version 0.12.2
Ignoring unf_ext-0.0.7.2 because its extensions are not built.  Try: gem pristine unf_ext --version 0.0.7.2
NAME
    opsicle - Opsworks Command Line Utility Belt


DOCUMENTATION
    For documentation and help in setting up your configuration files,
    see Opsicle's GitHub repo: https://github.com/sportngin/opsicle


SYNOPSIS
    opsicle [global options] command [command options] [arguments...]

VERSION
    2.3.0

GLOBAL OPTIONS
    --[no-]color - Use colored output (default: enabled)
    --debug      - Enable Debug mode for detailed logs and backtraces
    --help       - Show this message
    --mfa        - Use MFA for this command (some AWS operations will fail without it based on policy)
    --verbose    - Enable Verbose mode for more logging
    --version    - Display the program version

COMMANDS
    chef-update                 - Update the Stack Custom Chef Cookbooks
    clone-instance              - Clone instances in the given environment stack
    deploy                      - Deploy your current app to the given environment stack
    execute-recipes             - Execute arbitrary recipes on the Stack
    failure-log                 - Get most recent failure log for a stack
    help                        - Shows a list of commands or help for one command
    instances                   - List all instances in the given environment stack
    legacy-credential-converter - Convert the ~/.fog file to a ~/.aws/credentials file
    list                        - List all apps in the given environment stack
    monitor                     - Launch the Opsicle Stack Monitor for the given environment stack
    opsworks-url                - Show the OpsWorks URL for the given environment stack
    ssh                         - SSH access to instances in the given environment stack
    ssh-clean-keys              - Clear an environment's keys from your ssh known_hosts file
    ssh-key                     - Set your user SSH key (PUBLIC KEY) for OpsWorks
    update                      - Update properties on a OpsWorks resource.
    user-profile-info           - Display IAM user profile information as JSON.
```

After the change, the warnings preceding the command help go away.

QA Plan
-------
> Fill in scenarios below in checklist format.
> Consider Regression scenarios (did we break something else related to this change) in addition to Happy Path (testing the new feature directly).
> Evaluate the risk level and label accordingly and ensure the QA Plan matches the risk level!

- [ ] Example scenario

