### PR TITLE
Fix sandbox permissions with gem spec cache

### DIFF
--- a/lib/brew/gem/formula.rb.erb
+++ b/lib/brew/gem/formula.rb.erb
@@ -7,6 +7,7 @@ class RubyGemsDownloadStrategy < AbstractDownloadStrategy
   def fetch
     ohai "Fetching <%= name %> from gem source"
     HOMEBREW_CACHE.cd do
+      ENV['GEM_SPEC_CACHE'] = "#{HOMEBREW_CACHE}/gem_spec_cache"
       system "gem", "fetch", "<%= name %>", "--version", resource.version
     end
   end

--- a/spec/support/aruba.rb
+++ b/spec/support/aruba.rb
@@ -7,6 +7,9 @@ module BrewGemBin
 end
 
 module CleanEnv
+  OUR_BREW_GEM_HOME = File.expand_path('../../..', __FILE__)
+  OUR_BREW_GEM_BIN  = "#{OUR_BREW_GEM_HOME}/bin"
+
   def run(*args)
     clean_env = Bundler.clean_env
     (ENV.keys - clean_env.keys).each {|k| delete_environment_variable k }
@@ -16,8 +19,11 @@ module CleanEnv
     delete_environment_variable "GEM_PATH"
     delete_environment_variable "GEM_HOME"
     path = ENV['PATH'].split(/:/)
-    # Remove .rvm/.rbenv stuff from PATH
-    set_environment_variable "PATH", path.reject {|x| x =~ %r{/.(rvm|rbenv)/} }.join(":")
+    # Remove .rvm/.rbenv/.bundle stuff from PATH
+    path = path.reject {|x| x =~ %r{/.(rvm|rbenv)/} || x =~ %r{#{OUR_BREW_GEM_HOME}/.bundle} }
+    # Ensure that `brew` finds our local `brew-gem` command by putting it first in the path
+    path.unshift OUR_BREW_GEM_BIN unless path.first == OUR_BREW_GEM_BIN
+    set_environment_variable "PATH", path.join(":")
     super
   end
 end


### PR DESCRIPTION
What
----------------------
Fixes gem fetch permissions issues caused by Homebrew turning on the sandbox for all taps.

Why
----------------------
> Why is this being changed?  Provide some context that may help future developers understand the reasoning behind these changes. Quote and/or link to requirements, keeping in mind that JIRA/A-HA/etc links may not be available in the future.

URLs
----
- #47 

QA Plan
-------
- [x] Ensure current `brew gem install bundler` fails:
```
rm -f `brew --cache`/bundler*.gem
brew gem install bundler
```
- [x] Ensure `brew gem install bundler` succeeds with new brew gem executable on branch:
```
PATH=./bin:$PATH brew gem install bundler
```

