### PR TITLE
Add --disable-gems to binstubs

### DIFF
--- a/lib/brew/gem/formula.rb.erb
+++ b/lib/brew/gem/formula.rb.erb
@@ -74,7 +74,7 @@ class <%= klass %> < Formula
       file = Pathname.new("#{brew_gem_prefix}/#{gemspec.bindir}/#{exe}")
       (bin+file.basename).open('w') do |f|
         f << <<-RUBY
-#!#{ruby_path}
+#!#{ruby_path} --disable-gems
 ENV['GEM_HOME']="#{prefix}"
 ENV['GEM_PATH']="#{prefix}"
 $:.unshift(#{ruby_libs.map(&:inspect).join(",")})

--- a/lib/brew/gem/formula.rb.erb
+++ b/lib/brew/gem/formula.rb.erb
@@ -77,6 +77,7 @@ class <%= klass %> < Formula
 #!#{ruby_path} --disable-gems
 ENV['GEM_HOME']="#{prefix}"
 ENV['GEM_PATH']="#{prefix}"
+require 'rubygems'
 $:.unshift(#{ruby_libs.map(&:inspect).join(",")})
 load "#{file}"
         RUBY


### PR DESCRIPTION
What
----------------------
Adds `--disable-gems` to the shebang line of installed binstubs.

Why
----------------------
Prevents interaction with RVM rubies and other installed ruby environments when brew-gem-installed utilities are run inside them.
