### PR TITLE
Install with homebrew ruby by default, if present

### DIFF
--- a/lib/brew/gem/cli.rb
+++ b/lib/brew/gem/cli.rb
@@ -14,6 +14,10 @@ module Brew::Gem::CLI
     "help"      => "This message"
   }
 
+  HOMEBREW_RUBY_FLAG = "--homebrew-ruby"
+  SYSTEM_RUBY_FLAG   = "--system-ruby"
+  FLAGS = [HOMEBREW_RUBY_FLAG, SYSTEM_RUBY_FLAG]
+
   def help_msg
     (["Please specify a gem name (e.g. brew gem command <name>)"] +
       COMMANDS.map {|name, desc| "  #{name} - #{desc}"}).join("\n")
@@ -63,15 +67,15 @@ module Brew::Gem::CLI
     File.unlink filename
   end
 
+
   def run(args = ARGV)
-    command, name, supplied_version, homebrew_ruby = process_args(args)
-    homebrew_ruby_flag = "--homebrew-ruby"
-    if supplied_version == homebrew_ruby_flag
-      supplied_version = nil
-      homebrew_ruby = homebrew_ruby_flag
+    command, name, supplied_version, ruby_flag = process_args(args)
+
+    if FLAGS.include?(supplied_version)
+      supplied_version, ruby_flag = ruby_flag, supplied_version
     end
 
-    use_homebrew_ruby = homebrew_ruby == homebrew_ruby_flag
+    use_homebrew_ruby = ruby_flag.nil? || ruby_flag == HOMEBREW_RUBY_FLAG
 
     version = fetch_version(name, supplied_version)
 

--- a/lib/brew/gem/cli.rb
+++ b/lib/brew/gem/cli.rb
@@ -1,5 +1,6 @@
 require 'erb'
 require 'tempfile'
+require 'shellwords'
 
 module Brew::Gem::CLI
   module_function
@@ -112,7 +113,7 @@ module Brew::Gem::CLI
       when "formula"
         $stdout.puts File.read(filename)
       else
-        system "brew #{arguments.to_args.join(' ')} #{filename}"
+        system "brew #{arguments.to_args.shelljoin} #{filename}"
         exit $?.exitstatus unless $?.success?
       end
     end

--- a/lib/brew/gem/formula.rb.erb
+++ b/lib/brew/gem/formula.rb.erb
@@ -42,6 +42,12 @@ class <%= klass %> < Formula
     ENV['GEM_HOME']="#{prefix}"
     ENV['GEM_PATH']="#{prefix}"
 
+    # Use /usr/local/bin at the front of the path instead of Homebrew shims,
+    # which mess with Ruby's own compiler config when building native extensions
+    if defined?(HOMEBREW_SHIMS_PATH)
+      ENV['PATH'] = ENV['PATH'].sub(HOMEBREW_SHIMS_PATH.to_s, '/usr/local/bin')
+    end
+
     system BREWGEM_GEM_PATH, "install", cached_download,
              "--no-ri",
              "--no-rdoc",

--- a/spec/brew/gem/cli_spec.rb
+++ b/spec/brew/gem/cli_spec.rb
@@ -2,9 +2,10 @@ require 'spec_helper'
 
 RSpec.describe Brew::Gem::CLI do
   before { ENV['HOMEBREW_PREFIX'] = '/usr/local' }
+  let(:cli) { described_class }
 
   context "#expand_formula" do
-    subject(:formula) { described_class.expand_formula("foo-bar", "1.2.3", false) }
+    subject(:formula) { cli.expand_formula("foo-bar", "1.2.3", false) }
 
     it "generates valid Ruby" do
       IO.popen("ruby -c -", "r+") { |f| f.puts formula }
@@ -18,9 +19,47 @@ RSpec.describe Brew::Gem::CLI do
     it { is_expected.to match("BREWGEM_RUBYBINDIR = '/usr/bin'") }
 
     context "homebrew-ruby" do
-      subject(:formula) { described_class.expand_formula("foo-bar", "1.2.3", true) }
+      subject(:formula) { cli.expand_formula("foo-bar", "1.2.3", true) }
       it { is_expected.to match("BREWGEM_RUBYBINDIR = '/usr/local/bin'") }
     end
   end
 
+  context "#run" do
+    let(:gem)     { 'dummygem' }
+    let(:version) { '1.0.1.0' }
+    let(:formula) { 'temp-formula.rb' }
+    let(:command) { '' }
+
+    before do
+      allow(cli).to receive(:exit)
+      allow(cli).to receive(:system) {|x| command << x }
+      allow(cli).to receive(:with_temp_formula).and_yield(formula)
+      allow(cli).to receive(:fetch_version) {|n,v| v || version }
+      allow(cli).to receive(:abort) {|msg| raise msg }
+    end
+
+    it 'runs brew on a formula file' do
+      cli.run ['install', gem]
+      expect(command.split).to eql(['brew', 'install', formula])
+    end
+
+    it 'accepts an optional requested version' do
+      cli.run ['install', gem, '2.2.2']
+      expect(command.split).to eql(['brew', 'install', formula])
+      expect(cli).to have_received(:with_temp_formula).with(gem, '2.2.2', true)
+    end
+
+    it 'accepts a --homebrew-ruby flag' do
+      cli.run ['install', gem, '--homebrew-ruby']
+      expect(command.split).to eql(['brew', 'install', formula])
+      expect(cli).to have_received(:with_temp_formula).with(gem, version, true)
+    end
+
+    it 'accepts a --system-ruby flag' do
+      cli.run ['install', gem, '--system-ruby']
+      expect(command.split).to eql(['brew', 'install', formula])
+      expect(cli).to have_received(:with_temp_formula).with(gem, version, false)
+    end
+
+  end
 end

--- a/spec/brew/gem/cli_spec.rb
+++ b/spec/brew/gem/cli_spec.rb
@@ -43,6 +43,28 @@ RSpec.describe Brew::Gem::CLI do
       expect(command.split).to eql(['brew', 'install', formula])
     end
 
+    context 'with a homebrew ruby installed' do
+      before do
+        allow(File).to receive(:exist?).with('/usr/local/opt/ruby').and_return true
+      end
+
+      it 'installs with homebrew ruby by default' do
+        cli.run ['install', gem]
+        expect(cli).to have_received(:with_temp_formula).with(gem, version, true)
+      end
+    end
+
+    context 'with a homebrew ruby not installed' do
+      before do
+        allow(File).to receive(:exist?).with('/usr/local/opt/ruby').and_return false
+      end
+
+      it 'installs with system ruby by default' do
+        cli.run ['install', gem]
+        expect(cli).to have_received(:with_temp_formula).with(gem, version, false)
+      end
+    end
+
     it 'accepts an optional requested version' do
       cli.run ['install', gem, '2.2.2']
       expect(command.split).to eql(['brew', 'install', formula])


### PR DESCRIPTION
What
----------------------
- Install brew gems with homebrew ruby by default, if homebrew ruby is installed
- Fix issue where homebrew superenv shims were interfering with Ruby's ability to compile native extensions.

URLs
----
> Links to bug tickets or user stories.

QA Plan
-------
- [x] Pull down this branch and run:
```
PATH=./bin:$PATH brew gem install <gem>
```
- [x] Ensure that the gem installed successfully.
- [x] Inspect the binstub created for the gem and ensure that `#!/usr/local/bin/ruby` is at the top, indicating it is installed to use homebrew ruby.