### PR TITLE
FIX of installation of brew-gems, RubyGems=>3.0.2

### DIFF
--- a/lib/brew/gem/formula.rb.erb
+++ b/lib/brew/gem/formula.rb.erb
@@ -60,8 +60,7 @@ class <%= klass %> < Formula
     end
 
     system BREWGEM_GEM_PATH, "install", cached_download,
-             "--no-ri",
-             "--no-rdoc",
+             "--no-document",
              "--no-wrapper",
              "--no-user-install",
              "--install-dir", prefix,


### PR DESCRIPTION
IF RubyGems=>3.0.2 only supported parameter is --no-document
Where are some discussions here https://github.com/jordansissel/fpm/pull/1583 and here https://github.com/jordansissel/fpm/issues/1582 (If RubyGems < 2 this PR breaks installation)