### PR TITLE
Use PKG_CONFIG_PATH from environment

### DIFF
--- a/lib/brew/gem/formula.rb.erb
+++ b/lib/brew/gem/formula.rb.erb
@@ -4,6 +4,7 @@ require 'formula'
 require 'fileutils'
 
 USE_HOMEBREW_RUBY = <%= use_homebrew_ruby ? "true" : "false" %>
+BREW_GEM_PKG_CONFIG_PATH = <%= ENV['PKG_CONFIG_PATH'] && ENV['PKG_CONFIG_PATH'].inspect %>
 
 module RubyBin
   def ruby_bin
@@ -66,6 +67,17 @@ class <%= klass %> < Formula
     # which mess with Ruby's own compiler config when building native extensions
     if defined?(HOMEBREW_SHIMS_PATH)
       ENV['PATH'] = ENV['PATH'].sub(HOMEBREW_SHIMS_PATH.to_s, '/usr/local/bin')
+    end
+
+    # Allow injecting pkg config into paths. For gems that have native
+    # extensions, we need a way to inject build information into the extconf.rb
+    # process. Many extconf.rb files already use pkg_config to get this
+    # information. It's not straightforward to use Homebrew formula dependencies
+    # in a reliable way since the dependencies vary from gem to gem.
+    if BREW_GEM_PKG_CONFIG_PATH
+      ENV['PKG_CONFIG_PATH'] = [BREW_GEM_PKG_CONFIG_PATH,
+                                ENV['PKG_CONFIG_PATH']
+                               ].compact.join(File::PATH_SEPARATOR)
     end
 
     system "#{ruby_bin}/gem", "install", cached_download,

--- a/spec/brew/gem/cli_spec.rb
+++ b/spec/brew/gem/cli_spec.rb
@@ -22,6 +22,12 @@ RSpec.describe Brew::Gem::CLI do
       subject(:formula) { cli.expand_formula("foo-bar", "1.2.3", true) }
       it { is_expected.to match("USE_HOMEBREW_RUBY = true") }
     end
+
+    context "with PKG_CONFIG_PATH" do
+      before { ENV['PKG_CONFIG_PATH'] = '/usr/local/lib/pkgconfig' }
+
+      it { is_expected.to match('BREW_GEM_PKG_CONFIG_PATH = "/usr/local/lib/pkgconfig"')}
+    end
   end
 
   context "#run" do

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -12,7 +12,7 @@ end
 RSpec.configure do |c|
   c.filter_run focus: true
   c.run_all_when_everything_filtered = true
-  unless system('which brew > /dev/null')
+  if ENV['SKIP_INTEGRATION'] || !system('which brew > /dev/null')
     c.filter_run_excluding integration: true
   end
 end


### PR DESCRIPTION
What
----------------------
Allows injecting `$PKG_CONFIG_PATH` from the environment outside the `brew` command, for custom gem native extension build configuration.

Why
----------------------
Catalina 10.15 no longer has `/usr/include` and we might need to tell extconf to look elsewhere when building.

Deploy Plan
-----------
> Does Platform Operations need to know anything special about this deploy? Are migrations present?

Rollback Plan
-------------
* To roll back this change, revert the merge with: `git revert -m 1 MERGE_SHA` and perform another deploy.

URLs
----
- https://people.freedesktop.org/~dbn/pkg-config-guide.html

QA Plan
-------
> Reference commonly used Regression test plans on the [QA Wiki](https://github.com/sportngin/qa-tests/wiki)
> Fill in scenarios below in checklist format.
> Consider Regression scenarios (did we break something else related to this change) in addition to Happy Path (testing the new feature directly).
> Evaluate the risk level and label accordingly and ensure the QA Plan matches the risk level!

- A step to reproduce (e.g.: navigate to http://example.com/foo/bar; fill a field labeled "login:" with  "boo"; click "submit"; press <kbd>Enter</kbd>)
- [ ] An assertion to verify (e.g. "that we are redirected to user dashboard"; "there's a message on the top of page saying 'login successful'"
