### PR TITLE
Add gem arguments from command-line following '--'

### DIFF
--- a/CHANGELOG.markdown
+++ b/CHANGELOG.markdown
@@ -1,3 +1,9 @@
+#### v1.1.0
+
+* Allow arguments after `--` to be passed to `gem install`
+
+  > https://github.com/sportngin/brew-gem/pull/67
+
 #### v1.0.0
 
 * Fix homebrew ruby path (thanks Kaleb Lape)

--- a/lib/brew/gem/cli.rb
+++ b/lib/brew/gem/cli.rb
@@ -126,7 +126,7 @@ module Brew::Gem::CLI
       when "formula"
         $stdout.puts File.read(filename)
       else
-        system "brew #{arguments.to_brew_args.shelljoin} #{filename}"
+        system "brew #{arguments.to_brew_args.shelljoin} --formula #{filename}"
         exit $?.exitstatus unless $?.success?
       end
     end

--- a/lib/brew/gem/formula.rb.erb
+++ b/lib/brew/gem/formula.rb.erb
@@ -4,6 +4,7 @@ require 'formula'
 require 'fileutils'
 
 USE_HOMEBREW_RUBY = <%= use_homebrew_ruby ? "true" : "false" %>
+GEM_ARGUMENTS = <%= gem_arguments.inspect %>
 
 module RubyBin
   def ruby_bin
@@ -73,7 +74,7 @@ class <%= klass %> < Formula
              "--no-wrapper",
              "--no-user-install",
              "--install-dir", prefix,
-             "--bindir", bin
+             "--bindir", bin, *GEM_ARGUMENTS
 
     raise "gem install '<%= name %>' failed with status #{$?.exitstatus}" unless $?.success?
 

--- a/lib/brew/gem/version.rb
+++ b/lib/brew/gem/version.rb
@@ -1,5 +1,5 @@
 module Brew
   module Gem
-    VERSION = "1.0.0"
+    VERSION = "1.1.0"
   end
 end

--- a/spec/brew/gem/cli_spec.rb
+++ b/spec/brew/gem/cli_spec.rb
@@ -71,7 +71,7 @@ RSpec.describe Brew::Gem::CLI do
 
     it 'runs brew on a formula file' do
       cli.run ['install', gem]
-      expect(command.split).to eql(['brew', 'install', formula])
+      expect(command.split).to eql(['brew', 'install', '--formula', formula])
     end
 
     context 'with a homebrew ruby installed' do
@@ -92,37 +92,37 @@ RSpec.describe Brew::Gem::CLI do
 
     it 'accepts an optional requested version' do
       cli.run ['install', gem, '2.2.2']
-      expect(command.split).to eql(['brew', 'install', formula])
+      expect(command.split).to eql(['brew', 'install', '--formula', formula])
       expect(cli).to have_received(:with_temp_formula).with(gem, '2.2.2', true, [])
     end
 
     it 'accepts a --homebrew-ruby flag' do
       cli.run ['install', gem, '--homebrew-ruby']
-      expect(command.split).to eql(['brew', 'install', formula])
+      expect(command.split).to eql(['brew', 'install', '--formula', formula])
       expect(cli).to have_received(:with_temp_formula).with(gem, version, true, [])
     end
 
     it 'accepts a --homebrew-ruby flag anywhere' do
       cli.run ['install', '--homebrew-ruby', gem]
-      expect(command.split).to eql(['brew', 'install', formula])
+      expect(command.split).to eql(['brew', 'install', '--formula', formula])
       expect(cli).to have_received(:with_temp_formula).with(gem, version, true, [])
     end
 
     it 'accepts a --system-ruby flag' do
       cli.run ['install', gem, '--system-ruby']
-      expect(command.split).to eql(['brew', 'install', formula])
+      expect(command.split).to eql(['brew', 'install', '--formula', formula])
       expect(cli).to have_received(:with_temp_formula).with(gem, version, false, [])
     end
 
     it 'accepts other flags and keeps the order' do
       cli.run ['-v', 'uninstall', '--force', gem, '2.1.2']
-      expect(command.split).to eql(['brew', '-v', 'uninstall', '--force', formula])
+      expect(command.split).to eql(['brew', '-v', 'uninstall', '--force', '--formula', formula])
       expect(cli).to have_received(:with_temp_formula).with(gem, '2.1.2', true, [])
     end
 
     it 'accepts flags for gem install and keeps the order' do
       cli.run ['-v', 'uninstall', '--force', gem, '2.1.2', '--', '--with-cflags=-Wall']
-      expect(command.split).to eql(['brew', '-v', 'uninstall', '--force', formula])
+      expect(command.split).to eql(['brew', '-v', 'uninstall', '--force', '--formula', formula])
       expect(cli).to have_received(:with_temp_formula).with(gem, '2.1.2', true, ['--', '--with-cflags=-Wall'])
     end
   end

--- a/spec/brew/gem/cli_spec.rb
+++ b/spec/brew/gem/cli_spec.rb
@@ -4,6 +4,35 @@ RSpec.describe Brew::Gem::CLI do
   before { ENV['HOMEBREW_PREFIX'] = '/usr/local' }
   let(:cli) { described_class }
 
+  context "Arguments" do
+    let(:args) { ['install', 'gli', '1.0', '--homebrew-ruby', '--force', '--', '--with-cflags=-Wall'] }
+    subject { described_class::Arguments.new args }
+
+    it 'parses the command name' do
+      expect(subject.command).to eq('install')
+    end
+
+    it 'parses the gem name' do
+      expect(subject.gem).to eq('gli')
+    end
+
+    it 'parses the version' do
+      expect(subject.supplied_version).to eq('1.0')
+    end
+
+    it 'parses the ruby flag' do
+      expect(subject.ruby_flag).to eq('--homebrew-ruby')
+    end
+
+    it 'parses the brew arguments' do
+      expect(subject.to_brew_args).to eq(['install', '--force'])
+    end
+
+    it 'parses the gem arguments' do
+      expect(subject.to_gem_args).to eq(['--', '--with-cflags=-Wall'])
+    end
+  end
+
   context "#expand_formula" do
     subject(:formula) { cli.expand_formula("foo-bar", "1.2.3", false) }
 
@@ -48,7 +77,7 @@ RSpec.describe Brew::Gem::CLI do
     context 'with a homebrew ruby installed' do
       it 'installs with homebrew ruby by default' do
         cli.run ['install', gem]
-        expect(cli).to have_received(:with_temp_formula).with(gem, version, true)
+        expect(cli).to have_received(:with_temp_formula).with(gem, version, true, [])
       end
     end
 
@@ -57,38 +86,44 @@ RSpec.describe Brew::Gem::CLI do
 
       it 'installs with system ruby by default' do
         cli.run ['install', gem]
-        expect(cli).to have_received(:with_temp_formula).with(gem, version, false)
+        expect(cli).to have_received(:with_temp_formula).with(gem, version, false, [])
       end
     end
 
     it 'accepts an optional requested version' do
       cli.run ['install', gem, '2.2.2']
       expect(command.split).to eql(['brew', 'install', formula])
-      expect(cli).to have_received(:with_temp_formula).with(gem, '2.2.2', true)
+      expect(cli).to have_received(:with_temp_formula).with(gem, '2.2.2', true, [])
     end
 
     it 'accepts a --homebrew-ruby flag' do
       cli.run ['install', gem, '--homebrew-ruby']
       expect(command.split).to eql(['brew', 'install', formula])
-      expect(cli).to have_received(:with_temp_formula).with(gem, version, true)
+      expect(cli).to have_received(:with_temp_formula).with(gem, version, true, [])
     end
 
     it 'accepts a --homebrew-ruby flag anywhere' do
       cli.run ['install', '--homebrew-ruby', gem]
       expect(command.split).to eql(['brew', 'install', formula])
-      expect(cli).to have_received(:with_temp_formula).with(gem, version, true)
+      expect(cli).to have_received(:with_temp_formula).with(gem, version, true, [])
     end
 
     it 'accepts a --system-ruby flag' do
       cli.run ['install', gem, '--system-ruby']
       expect(command.split).to eql(['brew', 'install', formula])
-      expect(cli).to have_received(:with_temp_formula).with(gem, version, false)
+      expect(cli).to have_received(:with_temp_formula).with(gem, version, false, [])
     end
 
     it 'accepts other flags and keeps the order' do
       cli.run ['-v', 'uninstall', '--force', gem, '2.1.2']
       expect(command.split).to eql(['brew', '-v', 'uninstall', '--force', formula])
-      expect(cli).to have_received(:with_temp_formula).with(gem, '2.1.2', true)
+      expect(cli).to have_received(:with_temp_formula).with(gem, '2.1.2', true, [])
+    end
+
+    it 'accepts flags for gem install and keeps the order' do
+      cli.run ['-v', 'uninstall', '--force', gem, '2.1.2', '--', '--with-cflags=-Wall']
+      expect(command.split).to eql(['brew', '-v', 'uninstall', '--force', formula])
+      expect(cli).to have_received(:with_temp_formula).with(gem, '2.1.2', true, ['--', '--with-cflags=-Wall'])
     end
   end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -12,7 +12,7 @@ end
 RSpec.configure do |c|
   c.filter_run focus: true
   c.run_all_when_everything_filtered = true
-  unless system('which brew > /dev/null')
+  unless system('which brew > /dev/null') && ENV['INTEGRATION']
     c.filter_run_excluding integration: true
   end
 end


### PR DESCRIPTION
Allows for passing arguments to `gem install` such as `-- --with-cflags=-Wno-implicit-function-declaration` to get past compile issues.

```
brew gem install curses -- --with-cflags=-Wno-implicit-function-declaration
```